### PR TITLE
🔒 Enforce ESLint and TypeScript checks during build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,10 +3,10 @@ import type {NextConfig} from 'next';
 const nextConfig: NextConfig = {
   /* config options here */
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
🎯 **What:** Fixed insecure Next.js configurations that ignored TypeScript errors and ESLint warnings during builds.
⚠️ **Risk:** Ignoring these checks could allow broken or insecure code to be deployed, leading to potential runtime errors or missed security issues identified by linters.
🛡️ **Solution:** Updated `next.config.ts` to set `ignoreBuildErrors: false` and `ignoreDuringBuilds: false` to enforce code quality and ensure build consistency.

---
*PR created automatically by Jules for task [16495097678957018762](https://jules.google.com/task/16495097678957018762) started by @GaseousIce*