### PR TITLE
🎨 Palette: UX and Accessibility enhancements for Recipe Generator

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-07-04 - Screen Reader Announcements for Dynamic Content
+**Learning:** When displaying long, dynamically generated text blocks (like a multi-paragraph recipe), wrapping the entire content in `aria-live` can result in a disruptive user experience because the screen reader will abruptly read out the entire long text. It's much better UX to use a polite `aria-live` region purely to communicate the high-level status changes (e.g. "Generating recipe...", "Recipe generated successfully"), allowing the user to navigate the new content at their own pace using standard reading controls.
+**Action:** Use a dedicated, hidden `aria-live="polite"` element for status updates and avoid placing `aria-live` on large text elements directly.

--- a/src/components/recipe/recipe-generator.tsx
+++ b/src/components/recipe/recipe-generator.tsx
@@ -39,6 +39,13 @@ export function RecipeGenerator() {
     },
   });
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      form.handleSubmit(onSubmit)();
+    }
+  };
+
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setIsLoading(true);
     setError(null);
@@ -76,12 +83,15 @@ export function RecipeGenerator() {
                 name="ingredients"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel htmlFor="ingredients-input" className="text-lg">Ingredients</FormLabel>
+                    <FormLabel htmlFor="ingredients-input" className="text-lg">
+                      Ingredients <span className="text-red-500" aria-hidden="true">*</span>
+                    </FormLabel>
                     <FormControl>
                       <Textarea
                         id="ingredients-input"
                         placeholder="e.g., chicken breast, broccoli, soy sauce, garlic"
                         className="min-h-[100px] resize-y"
+                        onKeyDown={handleKeyDown}
                         {...field}
                       />
                     </FormControl>
@@ -153,6 +163,9 @@ export function RecipeGenerator() {
                   <>
                     <Sparkles className="mr-2 h-4 w-4" />
                     Generate Recipe
+                    <kbd className="ml-2 hidden rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100 sm:inline-block">
+                      <span className="text-xs">⌘</span> Enter
+                    </kbd>
                   </>
                 )}
               </Button>
@@ -160,6 +173,13 @@ export function RecipeGenerator() {
           </Form>
         </CardContent>
       </Card>
+
+      {/* Screen reader only status announcements */}
+      <div aria-live="polite" className="sr-only">
+        {isLoading && "Generating recipe, please wait."}
+        {error && `Error: ${error}`}
+        {recipe && "Recipe generated successfully. Results are below."}
+      </div>
 
       {error && (
         <Alert variant="destructive" className="shadow-md">


### PR DESCRIPTION
💡 What: 
- Added a required field indicator `*` to the Ingredients textarea label.
- Added a `Cmd/Ctrl + Enter` keyboard shortcut to submit the form directly from the textarea, with a visual hint on the submit button.
- Added an `aria-live="polite"` screen-reader only region to announce loading, error, and success states dynamically.
- Documented the learning about using `aria-live` for dynamic status updates in `.Jules/palette.md`.

🎯 Why: 
- Clarifies required fields visually for all users.
- Provides power users with a quick way to submit the form without needing to tab to or click the submit button.
- Ensures screen reader users are aware of the status changes (e.g. when the recipe finishes generating) without forcing the screen reader to read the entire newly generated recipe all at once. 

📸 Before/After: Visual changes include the required field `*` and the `⌘ Enter` hint on the button. Verified via Playwright.

♿ Accessibility: 
- Better context for form requirements (the `*` is hidden from SR, while the field remains `required`).
- Screen-reader friendly non-disruptive polite status announcements during loading and generation.

---
*PR created automatically by Jules for task [11672376787170062136](https://jules.google.com/task/11672376787170062136) started by @GaseousIce*