### PR TITLE
🧹 Remove unused variables and eslint-disable in use-toast.ts

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -18,14 +18,6 @@ type ToasterToast = ToastProps & {
   action?: ToastActionElement
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const actionTypes = {
-  ADD_TOAST: "ADD_TOAST",
-  UPDATE_TOAST: "UPDATE_TOAST",
-  DISMISS_TOAST: "DISMISS_TOAST",
-  REMOVE_TOAST: "REMOVE_TOAST",
-} as const satisfies Record<string, string>;
-
 let count = 0;
 
 function genId() {
@@ -33,23 +25,21 @@ function genId() {
   return count.toString()
 }
 
-type ActionType = typeof actionTypes
-
 type Action =
   | {
-      type: ActionType["ADD_TOAST"]
+      type: "ADD_TOAST"
       toast: ToasterToast
     }
   | {
-      type: ActionType["UPDATE_TOAST"]
+      type: "UPDATE_TOAST"
       toast: Partial<ToasterToast>
     }
   | {
-      type: ActionType["DISMISS_TOAST"]
+      type: "DISMISS_TOAST"
       toastId?: ToasterToast["id"]
     }
   | {
-      type: ActionType["REMOVE_TOAST"]
+      type: "REMOVE_TOAST"
       toastId?: ToasterToast["id"]
     }
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `actionTypes` variable, its `ActionType` type alias, and the associated eslint-disable comment in `src/hooks/use-toast.ts`. Updated the `Action` discriminated union type to use explicit string literals.
💡 **Why:** This improves code maintainability by eliminating dead code and an unnecessary ESLint bypass.
✅ **Verification:** Ran `npm run typecheck` and `npm run lint` successfully, verifying no type or lint errors. Requested a code review which passed with no issues. 
✨ **Result:** A cleaner codebase with fewer linting suppressions and dead code.

---
*PR created automatically by Jules for task [273541983741375736](https://jules.google.com/task/273541983741375736) started by @GaseousIce*