### PR TITLE
🧹 Refactor repeated hit area styles in sidebar.tsx

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -26,6 +26,9 @@ const SIDEBAR_WIDTH_MOBILE = "18rem"
 const SIDEBAR_WIDTH_ICON = "3rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 
+// Increases the hit area of the button on mobile.
+const SIDEBAR_MOBILE_HIT_AREA = "after:absolute after:-inset-2 after:md:hidden"
+
 type SidebarContext = {
   state: "expanded" | "collapsed"
   open: boolean
@@ -461,8 +464,7 @@ const SidebarGroupAction = React.forwardRef<
       data-sidebar="group-action"
       className={cn(
         "absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
-        // Increases the hit area of the button on mobile.
-        "after:absolute after:-inset-2 after:md:hidden",
+        SIDEBAR_MOBILE_HIT_AREA,
         "group-data-[collapsible=icon]:hidden",
         className
       )}
@@ -607,8 +609,7 @@ const SidebarMenuAction = React.forwardRef<
       data-sidebar="menu-action"
       className={cn(
         "absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0",
-        // Increases the hit area of the button on mobile.
-        "after:absolute after:-inset-2 after:md:hidden",
+        SIDEBAR_MOBILE_HIT_AREA,
         "peer-data-[size=sm]/menu-button:top-1",
         "peer-data-[size=default]/menu-button:top-1.5",
         "peer-data-[size=lg]/menu-button:top-2.5",


### PR DESCRIPTION
🎯 **What:** Extracted the repetitive class string `"after:absolute after:-inset-2 after:md:hidden"` and its associated comment from `SidebarGroupAction` and `SidebarMenuAction` into a single constant `SIDEBAR_MOBILE_HIT_AREA` at the top of the file.
💡 **Why:** Reduces code duplication, adheres to DRY principles, and makes the file cleaner to maintain.
✅ **Verification:** Ran `npm run lint`, `npm run typecheck` and `npx next build` to verify no regressions were introduced. Evaluated that this strictly preserves existing UI behavior.
✨ **Result:** A more readable and maintainable `sidebar.tsx` component.

---
*PR created automatically by Jules for task [18344435496963944473](https://jules.google.com/task/18344435496963944473) started by @GaseousIce*